### PR TITLE
Refactored to use setState functions instead of objects

### DIFF
--- a/src/context-store--indexable/modifiers/get-create-one-context-data.test.ts
+++ b/src/context-store--indexable/modifiers/get-create-one-context-data.test.ts
@@ -25,7 +25,6 @@ describe(getTestName(__dirname), () => {
 
     describe("Object storage", () => {
       it("Add a new entry when only action is defined", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -35,6 +34,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getCreateOneContextData(
           statefulIndexStore,
           setContextData,
@@ -56,7 +58,7 @@ describe(getTestName(__dirname), () => {
           name: "name 1",
         });
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -69,7 +71,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been called first with then success
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -88,7 +90,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Add a new entry in preload and updates it in action", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -98,6 +99,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getCreateOneContextData(
           statefulIndexStore,
           setContextData,
@@ -122,7 +126,7 @@ describe(getTestName(__dirname), () => {
           name: "name 1",
         });
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -139,7 +143,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been called first with then success
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -158,7 +162,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Add a new entry in preload and throws error in action", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -168,6 +171,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
 
         // Expect the call to reject with the same error found in the action
         await expect(
@@ -191,7 +197,7 @@ describe(getTestName(__dirname), () => {
         ).rejects.toEqual(errorString);
 
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -208,7 +214,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been called first with then success
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -225,7 +231,6 @@ describe(getTestName(__dirname), () => {
 
     describe("Array storage - adding to beginning", () => {
       it("Add a new entry when only action is defined", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserArrayContextStore = {
           data: [
             {
@@ -235,6 +240,9 @@ describe(getTestName(__dirname), () => {
           ],
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getCreateOneContextData(
           statefulIndexStore,
           setContextData,
@@ -256,7 +264,7 @@ describe(getTestName(__dirname), () => {
           name: "name 1",
         });
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: [
@@ -269,7 +277,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been called first with then success
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: [
@@ -288,7 +296,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Add a new entry in preload and updates it in action", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserArrayContextStore = {
           data: [
             {
@@ -298,6 +305,9 @@ describe(getTestName(__dirname), () => {
           ],
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getCreateOneContextData(
           statefulIndexStore,
           setContextData,
@@ -322,7 +332,7 @@ describe(getTestName(__dirname), () => {
           name: "name 1",
         });
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: [
@@ -339,7 +349,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been called first with then success
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: [
@@ -358,7 +368,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Add a new entry in preload and throws error in action", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserArrayContextStore = {
           data: [
             {
@@ -368,6 +377,9 @@ describe(getTestName(__dirname), () => {
           ],
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
 
         // Expect the call to reject with the same error found in the action
         await expect(
@@ -391,7 +403,7 @@ describe(getTestName(__dirname), () => {
         ).rejects.toEqual(errorString);
 
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: [
@@ -408,7 +420,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been called first with then success
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: [
@@ -425,7 +437,6 @@ describe(getTestName(__dirname), () => {
 
     describe("Array storage - adding to end", () => {
       it("Add a new entry when only action is defined", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserArrayContextStore = {
           data: [
             {
@@ -435,6 +446,9 @@ describe(getTestName(__dirname), () => {
           ],
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getCreateOneContextData(
           statefulIndexStore,
           setContextData,
@@ -456,7 +470,7 @@ describe(getTestName(__dirname), () => {
           name: "name 1",
         });
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: [
@@ -469,7 +483,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been called first with then success
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: [
@@ -488,7 +502,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Add a new entry in preload and updates it in action", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserArrayContextStore = {
           data: [
             {
@@ -498,6 +511,9 @@ describe(getTestName(__dirname), () => {
           ],
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getCreateOneContextData(
           statefulIndexStore,
           setContextData,
@@ -522,7 +538,7 @@ describe(getTestName(__dirname), () => {
           name: "name 1",
         });
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: [
@@ -539,7 +555,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been called first with then success
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: [
@@ -558,7 +574,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Add a new entry in preload and throws error in action", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserArrayContextStore = {
           data: [
             {
@@ -568,6 +583,9 @@ describe(getTestName(__dirname), () => {
           ],
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
 
         // Expect the call to reject with the same error found in the action
         await expect(
@@ -591,7 +609,7 @@ describe(getTestName(__dirname), () => {
         ).rejects.toEqual(errorString);
 
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: [
@@ -608,7 +626,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been called first with then success
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: [
@@ -626,7 +644,6 @@ describe(getTestName(__dirname), () => {
 
   describe("setContextDataForCreateOne", () => {
     it("Adds a new entry when action is defined", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -636,8 +653,10 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await setContextDataForCreateOne(
-        statefulIndexStore,
         setContextData,
         {
           id: "1",
@@ -656,7 +675,8 @@ describe(getTestName(__dirname), () => {
         name: "name 1",
       });
       // Expect setContextData to have been set with the new store information
-      expect(setContextData).toHaveBeenCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
+        1,
         expect.objectContaining({
           data: {
             0: {

--- a/src/context-store--indexable/modifiers/get-create-one-context-data.ts
+++ b/src/context-store--indexable/modifiers/get-create-one-context-data.ts
@@ -32,7 +32,6 @@ export async function getCreateOneContextData<
     // Handle preload
     value =
       (await setContextDataForCreateOne(
-        contextData,
         setContextData,
         params,
         getIndex,
@@ -43,7 +42,6 @@ export async function getCreateOneContextData<
     // Handle action
     value =
       (await setContextDataForCreateOne(
-        contextData,
         setContextData,
         params,
         getIndex,
@@ -60,9 +58,11 @@ export async function getCreateOneContextData<
     try {
       // Creation failed, let's try to clean up but only if
       // we created a value in the first place
-      setContextData({
-        ...contextData,
-        state: statefulStates.error,
+      setContextData((contextData) => {
+        return {
+          ...contextData,
+          state: statefulStates.error,
+        };
       });
       if (typeof e === "string") {
         return Promise.reject(e);
@@ -72,9 +72,11 @@ export async function getCreateOneContextData<
         );
       }
     } catch {
-      setContextData({
-        ...contextData,
-        state: statefulStates.error,
+      setContextData((contextData) => {
+        return {
+          ...contextData,
+          state: statefulStates.error,
+        };
       });
       return Promise.reject(errorMessages.errorCallbackRejected);
     }
@@ -85,7 +87,6 @@ export async function setContextDataForCreateOne<
   Params,
   TContextStore extends IndexableContextStore<any>
 >(
-  contextData: TContextStore,
   setContextData: React.Dispatch<React.SetStateAction<TContextStore>>,
   params: Params,
   getIndex: (params: Params) => IndexableContextStoreKey<TContextStore>,
@@ -97,9 +98,9 @@ export async function setContextDataForCreateOne<
   // Handle preload scenario
   const index = getIndex(params);
   const value = action ? await action(params) : null;
-  setContextData(
-    getUpdatedContextDataForCreateOne(contextData, index, value, state)
-  );
+  setContextData((contextData) => {
+    return getUpdatedContextDataForCreateOne(contextData, index, value, state);
+  });
   return value;
 }
 

--- a/src/context-store--indexable/modifiers/get-delete-one-context-data.test.ts
+++ b/src/context-store--indexable/modifiers/get-delete-one-context-data.test.ts
@@ -19,7 +19,6 @@ describe(getTestName(__dirname), () => {
   describe("Reactive delete", () => {
     describe("action resolves", () => {
       it("Deletes item (setting states) and returns expected result", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -29,6 +28,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getDeleteOneContextData(
           statefulIndexStore,
           setContextData,
@@ -51,7 +53,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -64,7 +66,7 @@ describe(getTestName(__dirname), () => {
           })
         );
 
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {},
@@ -74,7 +76,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Updates item via preload, deletes item (setting states), and returns expected result", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -84,6 +85,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getDeleteOneContextData(
           statefulIndexStore,
           setContextData,
@@ -111,7 +115,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -124,7 +128,7 @@ describe(getTestName(__dirname), () => {
           })
         );
 
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {},
@@ -137,7 +141,7 @@ describe(getTestName(__dirname), () => {
     describe("action rejects", () => {
       it("rejects request and updates state to loading then error", async () => {
         const rejectErrorMessage = "Test reject error message";
-        const setContextData = jest.fn();
+
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -147,6 +151,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -165,7 +172,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -178,7 +185,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -194,7 +201,7 @@ describe(getTestName(__dirname), () => {
 
       it("rejects request and updates state to loading then custom error", async () => {
         const rejectErrorMessage = "Test reject error message";
-        const setContextData = jest.fn();
+
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -204,6 +211,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -228,7 +238,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -241,7 +251,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -256,7 +266,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Throws error if reject happens in error handler", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -266,6 +275,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         return expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -290,7 +302,7 @@ describe(getTestName(__dirname), () => {
     describe("action throws", () => {
       it("rejects request and updates state to loading then error", async () => {
         const rejectErrorMessage = "Test reject error message";
-        const setContextData = jest.fn();
+
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -300,6 +312,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -318,7 +333,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -331,7 +346,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -347,7 +362,7 @@ describe(getTestName(__dirname), () => {
 
       it("rejects request and updates state to loading then custom error", async () => {
         const rejectErrorMessage = "Test reject error message";
-        const setContextData = jest.fn();
+
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -357,6 +372,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -381,7 +399,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -394,7 +412,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -409,7 +427,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Throws error if reject happens in error handler", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -419,6 +436,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -440,7 +460,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -453,7 +473,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -471,7 +491,6 @@ describe(getTestName(__dirname), () => {
 
   describe("Pre-emptive", () => {
     it("Removes data pre-emptively if preload resolves null", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -481,6 +500,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await getDeleteOneContextData(
         statefulIndexStore,
         setContextData,
@@ -504,7 +526,7 @@ describe(getTestName(__dirname), () => {
         name: "name 0",
       });
       // Expect setContextData to have been called first with loading
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         1,
         expect.objectContaining({
           data: {},
@@ -512,7 +534,7 @@ describe(getTestName(__dirname), () => {
         })
       );
       // Expect setContextData to have been called first with then success
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         2,
         expect.objectContaining({
           data: {},
@@ -523,7 +545,6 @@ describe(getTestName(__dirname), () => {
   });
 
   it("Deletes an entry when action is defined", async () => {
-    const setContextData = jest.fn();
     const statefulIndexStore: UserMapContextStore = {
       data: {
         0: {
@@ -533,6 +554,9 @@ describe(getTestName(__dirname), () => {
       },
       state: "success",
     };
+    const setContextData = jest.fn((func) => {
+      return func(statefulIndexStore);
+    });
     const result = await setContextDataForDeleteOne(
       statefulIndexStore,
       setContextData,
@@ -552,7 +576,8 @@ describe(getTestName(__dirname), () => {
       name: "name 0",
     });
     // Expect setContextData to have been set with the new store information
-    expect(setContextData).toHaveBeenCalledWith(
+    expect(setContextData).toHaveNthReturnedWith(
+      1,
       expect.objectContaining({
         data: {},
         state: "loading",

--- a/src/context-store--indexable/modifiers/get-delete-one-context-data.ts
+++ b/src/context-store--indexable/modifiers/get-delete-one-context-data.ts
@@ -78,9 +78,11 @@ export async function getDeleteOneContextData<
         );
       }
     } catch {
-      setContextData({
-        ...contextData,
-        state: statefulStates.error,
+      setContextData((contextData) => {
+        return {
+          ...contextData,
+          state: statefulStates.error,
+        };
       });
       return Promise.reject(errorMessages.errorCallbackRejected);
     }
@@ -106,13 +108,15 @@ export async function setContextDataForDeleteOne<
   const oldValue = contextData.data[index];
   const defaultValue = deleteIfNull ? null : oldValue;
   const value = action ? await action(params) : defaultValue;
-  const newStore = getUpdatedContextDataForDeleteOne(
-    contextData,
-    index,
-    value,
-    state
-  );
-  setContextData(newStore);
+  setContextData((contextData) => {
+    const newStore = getUpdatedContextDataForDeleteOne(
+      contextData,
+      index,
+      value,
+      state
+    );
+    return newStore;
+  });
   return oldValue;
 }
 

--- a/src/context-store--indexable/modifiers/get-update-one-context-data.test.ts
+++ b/src/context-store--indexable/modifiers/get-update-one-context-data.test.ts
@@ -18,7 +18,6 @@ type UserMapContextStore = ContextStore<{
 describe(getTestName(__dirname), () => {
   describe("getUpdateOneContextData", () => {
     it("Updates an entry when only action is defined", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -28,6 +27,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await getUpdateOneContextData(
         statefulIndexStore,
         setContextData,
@@ -50,7 +52,7 @@ describe(getTestName(__dirname), () => {
         name: "name 1",
       });
       // Expect setContextData to have been called first with loading
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         1,
         expect.objectContaining({
           data: {
@@ -63,7 +65,7 @@ describe(getTestName(__dirname), () => {
         })
       );
       // Expect setContextData to have been called first with then success
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         2,
         expect.objectContaining({
           data: {
@@ -78,7 +80,6 @@ describe(getTestName(__dirname), () => {
     });
 
     it("Updates an entry when preload", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -88,6 +89,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await getUpdateOneContextData(
         statefulIndexStore,
         setContextData,
@@ -115,7 +119,7 @@ describe(getTestName(__dirname), () => {
         name: "New name 2",
       });
       // Expect setContextData to have been called first with loading
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         1,
         expect.objectContaining({
           data: {
@@ -128,7 +132,7 @@ describe(getTestName(__dirname), () => {
         })
       );
       // Expect setContextData to have been called first with then success
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         2,
         expect.objectContaining({
           data: {
@@ -143,7 +147,6 @@ describe(getTestName(__dirname), () => {
     });
 
     it("Rejects when index cannot be found", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -153,6 +156,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       await expect(
         getUpdateOneContextData(
           statefulIndexStore,
@@ -175,7 +181,6 @@ describe(getTestName(__dirname), () => {
 
   describe("setContextDataForUpdateOne", () => {
     it("Updates an existing entry when action is defined", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -185,6 +190,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await setContextDataForUpdateOne(
         statefulIndexStore,
         setContextData,
@@ -204,7 +212,8 @@ describe(getTestName(__dirname), () => {
         name: "name 1",
       });
       // Expect setContextData to have been set with the new store information
-      expect(setContextData).toHaveBeenCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
+        1,
         expect.objectContaining({
           data: {
             0: {

--- a/src/context-store--indexable/modifiers/get-update-one-context-data.ts
+++ b/src/context-store--indexable/modifiers/get-update-one-context-data.ts
@@ -75,9 +75,11 @@ export async function getUpdateOneContextData<
         return Promise.resolve(value);
       }
     } catch {
-      setContextData({
-        ...contextData,
-        state: statefulStates.error,
+      setContextData((contextData) => {
+        return {
+          ...contextData,
+          state: statefulStates.error,
+        };
       });
       return Promise.reject(errorMessages.errorCallbackRejected);
     }
@@ -96,19 +98,23 @@ export async function setContextDataForUpdateOne<
   action?: (
     params: Params
   ) => Promise<Partial<IndexableContextStoreValue<TContextStore>> | null>
-) {
+): Promise<IndexableContextStoreValue<TContextStore>> {
   // Handle preload scenario
   const index = getIndex(params);
   const value = action ? await action(params) : null;
 
-  const newStore = getUpdatedContextDataForUpdateOne(
-    contextData,
-    index,
-    value,
-    state
-  );
-  setContextData(newStore);
-  return newStore.data[index];
+  return new Promise((resolve) => {
+    setContextData((contextData) => {
+      const newStore = getUpdatedContextDataForUpdateOne(
+        contextData,
+        index,
+        value,
+        state
+      );
+      resolve(newStore.data[index]);
+      return newStore;
+    });
+  });
 }
 
 export function getUpdatedContextDataForUpdateOne<

--- a/src/context-store--stateful-indexable/modifiers/get-create-one-context-data.test.ts
+++ b/src/context-store--stateful-indexable/modifiers/get-create-one-context-data.test.ts
@@ -18,7 +18,6 @@ describe(getTestName(__dirname), () => {
     describe("adds into map", () => {
       describe("reactive", () => {
         it("Add a new entry when only action is defined", async () => {
-          const setContextData = jest.fn();
           const statefulIndexStore: UserMapContextStore = {
             data: {
               0: {
@@ -31,6 +30,9 @@ describe(getTestName(__dirname), () => {
             },
             state: "success",
           };
+          const setContextData = jest.fn((func) => {
+            return func(statefulIndexStore);
+          });
           const result = await getCreateOneContextData(
             statefulIndexStore,
             setContextData,
@@ -52,7 +54,7 @@ describe(getTestName(__dirname), () => {
             name: "name 1",
           });
           // Expect setContextData to have been called first with loading
-          expect(setContextData).toHaveBeenNthCalledWith(
+          expect(setContextData).toHaveNthReturnedWith(
             1,
             expect.objectContaining({
               data: {
@@ -68,7 +70,7 @@ describe(getTestName(__dirname), () => {
             })
           );
           // Expect setContextData to have been called first with then success
-          expect(setContextData).toHaveBeenNthCalledWith(
+          expect(setContextData).toHaveNthReturnedWith(
             2,
             expect.objectContaining({
               data: {
@@ -93,7 +95,6 @@ describe(getTestName(__dirname), () => {
         });
 
         it("Cleans up load state if action rejects", async () => {
-          const setContextData = jest.fn();
           const statefulIndexStore: UserMapContextStore = {
             data: {
               0: {
@@ -106,6 +107,9 @@ describe(getTestName(__dirname), () => {
             },
             state: "success",
           };
+          const setContextData = jest.fn((func) => {
+            return func(statefulIndexStore);
+          });
           const rejectMessage = "fail time";
           await expect(
             getCreateOneContextData(
@@ -125,7 +129,7 @@ describe(getTestName(__dirname), () => {
           ).rejects.toEqual(rejectMessage);
 
           // Expect setContextData to have been called first with loading
-          expect(setContextData).toHaveBeenNthCalledWith(
+          expect(setContextData).toHaveNthReturnedWith(
             1,
             expect.objectContaining({
               data: {
@@ -141,7 +145,7 @@ describe(getTestName(__dirname), () => {
             })
           );
           // Expect setContextData to have been called first with then success
-          expect(setContextData).toHaveBeenNthCalledWith(
+          expect(setContextData).toHaveNthReturnedWith(
             2,
             expect.objectContaining({
               data: {
@@ -161,7 +165,6 @@ describe(getTestName(__dirname), () => {
 
       describe("proactive", () => {
         it("Add a new entry when preload returns value", async () => {
-          const setContextData = jest.fn();
           const statefulIndexStore: UserMapContextStore = {
             data: {
               0: {
@@ -174,6 +177,9 @@ describe(getTestName(__dirname), () => {
             },
             state: "success",
           };
+          const setContextData = jest.fn((func) => {
+            return func(statefulIndexStore);
+          });
           const result = await getCreateOneContextData(
             statefulIndexStore,
             setContextData,
@@ -198,7 +204,7 @@ describe(getTestName(__dirname), () => {
             name: "name 1",
           });
           // Expect setContextData to have been called first with loading
-          expect(setContextData).toHaveBeenNthCalledWith(
+          expect(setContextData).toHaveNthReturnedWith(
             1,
             expect.objectContaining({
               data: {
@@ -221,7 +227,7 @@ describe(getTestName(__dirname), () => {
             })
           );
           // Expect setContextData to have been called first with then success
-          expect(setContextData).toHaveBeenNthCalledWith(
+          expect(setContextData).toHaveNthReturnedWith(
             2,
             expect.objectContaining({
               data: {
@@ -246,7 +252,6 @@ describe(getTestName(__dirname), () => {
         });
 
         it("Cleans up load state if action rejects", async () => {
-          const setContextData = jest.fn();
           const statefulIndexStore: UserMapContextStore = {
             data: {
               0: {
@@ -259,6 +264,9 @@ describe(getTestName(__dirname), () => {
             },
             state: "success",
           };
+          const setContextData = jest.fn((func) => {
+            return func(statefulIndexStore);
+          });
           const rejectMessage = "fail time";
           await expect(
             getCreateOneContextData(
@@ -284,7 +292,7 @@ describe(getTestName(__dirname), () => {
           ).rejects.toEqual(rejectMessage);
 
           // Expect setContextData to have been called first with loading
-          expect(setContextData).toHaveBeenNthCalledWith(
+          expect(setContextData).toHaveNthReturnedWith(
             1,
             expect.objectContaining({
               data: {
@@ -307,7 +315,7 @@ describe(getTestName(__dirname), () => {
             })
           );
           // Expect setContextData to have been called first with then success
-          expect(setContextData).toHaveBeenNthCalledWith(
+          expect(setContextData).toHaveNthReturnedWith(
             2,
             expect.objectContaining({
               data: {
@@ -330,7 +338,6 @@ describe(getTestName(__dirname), () => {
       describe("to the beginning", () => {
         describe("reactive", () => {
           it("Add a new entry when only action is defined", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -343,6 +350,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const result = await getCreateOneContextData(
               statefulIndexStore,
               setContextData,
@@ -364,7 +374,7 @@ describe(getTestName(__dirname), () => {
               name: "name 1",
             });
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -380,7 +390,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -405,7 +415,6 @@ describe(getTestName(__dirname), () => {
           });
 
           it("Does not add anything if action fails", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -418,6 +427,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const rejectMessage = "fail time";
             await expect(
               getCreateOneContextData(
@@ -437,7 +449,7 @@ describe(getTestName(__dirname), () => {
             ).rejects.toEqual(rejectMessage);
 
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -453,7 +465,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -471,7 +483,6 @@ describe(getTestName(__dirname), () => {
           });
 
           it("Leaves data if custom error handler returns a value", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -484,6 +495,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const rejectMessage = "fail time";
             await expect(
               getCreateOneContextData(
@@ -509,7 +523,7 @@ describe(getTestName(__dirname), () => {
             ).rejects.toEqual(rejectMessage);
 
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -525,7 +539,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -552,7 +566,6 @@ describe(getTestName(__dirname), () => {
 
         describe("proactive", () => {
           it("Add a new entry when preload returns value", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -565,6 +578,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const result = await getCreateOneContextData(
               statefulIndexStore,
               setContextData,
@@ -589,7 +605,7 @@ describe(getTestName(__dirname), () => {
               name: "name 1",
             });
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -612,7 +628,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -637,7 +653,6 @@ describe(getTestName(__dirname), () => {
           });
 
           it("Removes data on action error", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -650,6 +665,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const rejectMessage = "fail time";
             await expect(
               getCreateOneContextData(
@@ -675,7 +693,7 @@ describe(getTestName(__dirname), () => {
             ).rejects.toEqual(rejectMessage);
 
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -698,7 +716,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -716,7 +734,6 @@ describe(getTestName(__dirname), () => {
           });
 
           it("Leaves data with an error state if error handler is defined", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -729,6 +746,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const rejectMessage = "fail time";
             await expect(
               getCreateOneContextData(
@@ -760,7 +780,7 @@ describe(getTestName(__dirname), () => {
             ).rejects.toEqual(rejectMessage);
 
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -783,7 +803,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -812,7 +832,6 @@ describe(getTestName(__dirname), () => {
       describe("to the end", () => {
         describe("reactive", () => {
           it("Add a new entry when only action is defined", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -825,6 +844,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const result = await getCreateOneContextData(
               statefulIndexStore,
               setContextData,
@@ -846,7 +868,7 @@ describe(getTestName(__dirname), () => {
               name: "name 1",
             });
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -862,7 +884,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -887,7 +909,6 @@ describe(getTestName(__dirname), () => {
           });
 
           it("Cleans up load state if action rejects", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -900,6 +921,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const rejectMessage = "fail time";
             await expect(
               getCreateOneContextData(
@@ -919,7 +943,7 @@ describe(getTestName(__dirname), () => {
             ).rejects.toEqual(rejectMessage);
 
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -935,7 +959,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -955,7 +979,6 @@ describe(getTestName(__dirname), () => {
 
         describe("proactive", () => {
           it("Add a new entry when preload returns value", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -968,6 +991,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const result = await getCreateOneContextData(
               statefulIndexStore,
               setContextData,
@@ -992,7 +1018,7 @@ describe(getTestName(__dirname), () => {
               name: "name 1",
             });
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -1015,7 +1041,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -1040,7 +1066,6 @@ describe(getTestName(__dirname), () => {
           });
 
           it("Cleans up load state if action rejects", async () => {
-            const setContextData = jest.fn();
             const statefulIndexStore: UserArrayContextStore = {
               data: [
                 {
@@ -1053,6 +1078,9 @@ describe(getTestName(__dirname), () => {
               ],
               state: "success",
             };
+            const setContextData = jest.fn((func) => {
+              return func(statefulIndexStore);
+            });
             const rejectMessage = "fail time";
             await expect(
               getCreateOneContextData(
@@ -1078,7 +1106,7 @@ describe(getTestName(__dirname), () => {
             ).rejects.toEqual(rejectMessage);
 
             // Expect setContextData to have been called first with loading
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               1,
               expect.objectContaining({
                 data: [
@@ -1101,7 +1129,7 @@ describe(getTestName(__dirname), () => {
               })
             );
             // Expect setContextData to have been called first with then success
-            expect(setContextData).toHaveBeenNthCalledWith(
+            expect(setContextData).toHaveNthReturnedWith(
               2,
               expect.objectContaining({
                 data: [
@@ -1124,7 +1152,6 @@ describe(getTestName(__dirname), () => {
 
   describe("setContextDataForCreateOne", () => {
     it("Adds a new entry when action is defined", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -1137,6 +1164,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await setContextDataForCreateOne(
         statefulIndexStore,
         setContextData,
@@ -1157,7 +1187,8 @@ describe(getTestName(__dirname), () => {
         name: "name 1",
       });
       // Expect setContextData to have been set with the new store information
-      expect(setContextData).toHaveBeenCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
+        1,
         expect.objectContaining({
           data: {
             0: {

--- a/src/context-store--stateful-indexable/modifiers/get-create-one-context-data.ts
+++ b/src/context-store--stateful-indexable/modifiers/get-create-one-context-data.ts
@@ -69,9 +69,11 @@ export async function getCreateOneContextData<
         error
       );
     } else {
-      setContextData({
-        ...contextData,
-        state: statefulStates.success,
+      setContextData((contextData) => {
+        return {
+          ...contextData,
+          state: statefulStates.success,
+        };
       });
     }
     if (typeof e === "string") {
@@ -98,9 +100,9 @@ export async function setContextDataForCreateOne<
   // Handle preload scenario
   const index = getIndex(params);
   const value = action ? await action(params) : null;
-  setContextData(
-    getUpdatedContextDataForCreateOne(contextData, index, value, state)
-  );
+  setContextData((contextData) => {
+    return getUpdatedContextDataForCreateOne(contextData, index, value, state);
+  });
   return value;
 }
 

--- a/src/context-store--stateful-indexable/modifiers/get-delete-one-context-data.test.ts
+++ b/src/context-store--stateful-indexable/modifiers/get-delete-one-context-data.test.ts
@@ -17,7 +17,6 @@ describe(getTestName(__dirname), () => {
   describe("Reactive delete", () => {
     describe("action resolves", () => {
       it("Deletes item (setting states) and returns expected result", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             "0": {
@@ -30,6 +29,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getDeleteOneContextData(
           statefulIndexStore,
           setContextData,
@@ -52,7 +54,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -68,7 +70,7 @@ describe(getTestName(__dirname), () => {
           })
         );
 
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {},
@@ -78,7 +80,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Updates item via preload, deletes item (setting states), and returns expected result", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -91,6 +92,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         const result = await getDeleteOneContextData(
           statefulIndexStore,
           setContextData,
@@ -118,7 +122,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -134,7 +138,7 @@ describe(getTestName(__dirname), () => {
           })
         );
 
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {},
@@ -147,7 +151,7 @@ describe(getTestName(__dirname), () => {
     describe("action rejects", () => {
       it("rejects request and updates state to loading then error", async () => {
         const rejectErrorMessage = "Test reject error message";
-        const setContextData = jest.fn();
+
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -160,6 +164,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -178,7 +185,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -194,7 +201,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -213,7 +220,7 @@ describe(getTestName(__dirname), () => {
 
       it("rejects request and updates state to loading then custom error", async () => {
         const rejectErrorMessage = "Test reject error message";
-        const setContextData = jest.fn();
+
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -226,6 +233,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -250,7 +260,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -266,7 +276,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -284,7 +294,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Throws error if reject happens in error handler", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -297,6 +306,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -321,7 +333,7 @@ describe(getTestName(__dirname), () => {
     describe("action throws", () => {
       it("rejects request and updates state to loading then error", async () => {
         const rejectErrorMessage = "Test reject error message";
-        const setContextData = jest.fn();
+
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -334,6 +346,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -352,7 +367,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -368,7 +383,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -387,7 +402,7 @@ describe(getTestName(__dirname), () => {
 
       it("rejects request and updates state to loading then custom error", async () => {
         const rejectErrorMessage = "Test reject error message";
-        const setContextData = jest.fn();
+
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -400,6 +415,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -424,7 +442,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -440,7 +458,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -458,7 +476,6 @@ describe(getTestName(__dirname), () => {
       });
 
       it("Throws error if reject happens in error handler", async () => {
-        const setContextData = jest.fn();
         const statefulIndexStore: UserMapContextStore = {
           data: {
             0: {
@@ -471,6 +488,9 @@ describe(getTestName(__dirname), () => {
           },
           state: "success",
         };
+        const setContextData = jest.fn((func) => {
+          return func(statefulIndexStore);
+        });
         await expect(
           getDeleteOneContextData(
             statefulIndexStore,
@@ -492,7 +512,7 @@ describe(getTestName(__dirname), () => {
 
         expect(setContextData).toHaveBeenCalledTimes(2);
         // Expect setContextData to have been called first with loading
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           1,
           expect.objectContaining({
             data: {
@@ -508,7 +528,7 @@ describe(getTestName(__dirname), () => {
           })
         );
         // Expect setContextData to have been last called with error
-        expect(setContextData).toHaveBeenNthCalledWith(
+        expect(setContextData).toHaveNthReturnedWith(
           2,
           expect.objectContaining({
             data: {
@@ -529,7 +549,6 @@ describe(getTestName(__dirname), () => {
 
   describe("Pre-emptive", () => {
     it("Removes data pre-emptively if preload resolves null", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -542,6 +561,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await getDeleteOneContextData(
         statefulIndexStore,
         setContextData,
@@ -565,7 +587,7 @@ describe(getTestName(__dirname), () => {
         name: "name 0",
       });
       // Expect setContextData to have been called first with loading
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         1,
         expect.objectContaining({
           data: {},
@@ -573,7 +595,7 @@ describe(getTestName(__dirname), () => {
         })
       );
       // Expect setContextData to have been called first with then success
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         2,
         expect.objectContaining({
           data: {},
@@ -584,7 +606,6 @@ describe(getTestName(__dirname), () => {
   });
 
   it("Deletes an entry when action is defined", async () => {
-    const setContextData = jest.fn();
     const statefulIndexStore: UserMapContextStore = {
       data: {
         0: {
@@ -597,6 +618,9 @@ describe(getTestName(__dirname), () => {
       },
       state: "success",
     };
+    const setContextData = jest.fn((func) => {
+      return func(statefulIndexStore);
+    });
     const result = await setContextDataForDeleteOne(
       statefulIndexStore,
       setContextData,
@@ -616,7 +640,8 @@ describe(getTestName(__dirname), () => {
       name: "name 0",
     });
     // Expect setContextData to have been set with the new store information
-    expect(setContextData).toHaveBeenCalledWith(
+    expect(setContextData).toHaveNthReturnedWith(
+      1,
       expect.objectContaining({
         data: {},
         state: "success",

--- a/src/context-store--stateful-indexable/modifiers/get-delete-one-context-data.ts
+++ b/src/context-store--stateful-indexable/modifiers/get-delete-one-context-data.ts
@@ -117,18 +117,30 @@ export async function setContextDataForDeleteOne<
     const value = action ? await action(params) : defaultValue;
     // Handle data updates
     if (value != null) {
-      const newStore = getUpdatedContextDataForUpdateOne(
-        contextData,
-        index,
-        value,
-        state
-      );
-      setContextData(newStore);
+      const newStore = await new Promise<TContextStore>((resolve, reject) => {
+        setContextData((contextData) => {
+          try {
+            const newStore = getUpdatedContextDataForUpdateOne(
+              contextData,
+              index,
+              value,
+              state
+            );
+            resolve(newStore);
+            return newStore;
+          } catch (e) {
+            reject(e);
+            return contextData;
+          }
+        });
+      });
       // @ts-expect-error
       return newStore.data[index].data;
     } else {
-      const newStore = getUpdatedContextDataForDeleteOne(contextData, index);
-      setContextData(newStore);
+      setContextData((contextData) => {
+        const newStore = getUpdatedContextDataForDeleteOne(contextData, index);
+        return newStore;
+      });
       return oldValue;
     }
   } catch (e) {

--- a/src/context-store--stateful-indexable/modifiers/get-update-one-context-data.test.ts
+++ b/src/context-store--stateful-indexable/modifiers/get-update-one-context-data.test.ts
@@ -18,7 +18,6 @@ type UserMapContextStore = ContextStore<{
 describe(getTestName(__dirname), () => {
   describe("getUpdateOneContextData", () => {
     it("Updates an entry when only action is defined", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -31,6 +30,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await getUpdateOneContextData(
         statefulIndexStore,
         setContextData,
@@ -53,7 +55,7 @@ describe(getTestName(__dirname), () => {
         name: "name 1",
       });
       // Expect setContextData to have been called first with loading
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         1,
         expect.objectContaining({
           data: {
@@ -69,7 +71,7 @@ describe(getTestName(__dirname), () => {
         })
       );
       // Expect setContextData to have been called first with then success
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         2,
         expect.objectContaining({
           data: {
@@ -87,7 +89,6 @@ describe(getTestName(__dirname), () => {
     });
 
     it("Updates an entry when preload", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -100,6 +101,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await getUpdateOneContextData(
         statefulIndexStore,
         setContextData,
@@ -127,7 +131,7 @@ describe(getTestName(__dirname), () => {
         name: "New name 2",
       });
       // Expect setContextData to have been called first with loading
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         1,
         expect.objectContaining({
           data: {
@@ -143,7 +147,7 @@ describe(getTestName(__dirname), () => {
         })
       );
       // Expect setContextData to have been called first with then success
-      expect(setContextData).toHaveBeenNthCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
         2,
         expect.objectContaining({
           data: {
@@ -161,7 +165,6 @@ describe(getTestName(__dirname), () => {
     });
 
     it("Rejects when index cannot be found", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -174,6 +177,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       await expect(
         getUpdateOneContextData(
           statefulIndexStore,
@@ -196,7 +202,6 @@ describe(getTestName(__dirname), () => {
 
   describe("setContextDataForUpdateOne", () => {
     it("Updates an existing entry when action is defined", async () => {
-      const setContextData = jest.fn();
       const statefulIndexStore: UserMapContextStore = {
         data: {
           0: {
@@ -209,6 +214,9 @@ describe(getTestName(__dirname), () => {
         },
         state: "success",
       };
+      const setContextData = jest.fn((func) => {
+        return func(statefulIndexStore);
+      });
       const result = await setContextDataForUpdateOne(
         statefulIndexStore,
         setContextData,
@@ -228,7 +236,8 @@ describe(getTestName(__dirname), () => {
         name: "name 1",
       });
       // Expect setContextData to have been set with the new store information
-      expect(setContextData).toHaveBeenCalledWith(
+      expect(setContextData).toHaveNthReturnedWith(
+        1,
         expect.objectContaining({
           data: {
             0: {


### PR DESCRIPTION
We're using promises so the state can update between our calls to setContextData. By moving to functional updates we can get the state at the time of the individual update.