### PR TITLE
Rename getSyncExternalStoreParameters to getUseSyncExternalStoreArgs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Now to use this in a component, all you need is useSyncExternalStore:
 import { itemStore } from "../stores/item-store.js";
 
 export const Items = () => {
-  const snapshot = React.useSyncExternalStore(...itemStore.getSyncExternalStoreParameters());
+  const snapshot = React.useSyncExternalStore(...itemStore.getUseSyncExternalStoreArgs());
   const { state, data } = snapshot;
 
   const onRefresh = () => {
@@ -97,7 +97,7 @@ jest.unstable_mockModule("../stores/item-store.js", () => {
   return {
     mockStore: {
       getAll,
-      getSyncExternalStoreParameters: () => [
+      getUseSyncExternalStoreArgs: () => [
         // subscribe
         () => () => {},
         // snapshot

--- a/src/sync-external-store/example/component.test.tsx
+++ b/src/sync-external-store/example/component.test.tsx
@@ -11,7 +11,7 @@ jest.unstable_mockModule("./store.js", () => {
     mockStore: {
       fetchAsync,
       fetchSync,
-      getSyncExternalStoreParameters: () => [
+      getUseSyncExternalStoreArgs: () => [
         // subscribe
         () => () => {},
         // snapshot

--- a/src/sync-external-store/example/component.tsx
+++ b/src/sync-external-store/example/component.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { mockStore } from "./store.js";
 
 export const MockComponent = () => {
-  const snapshot = React.useSyncExternalStore(...mockStore.getSyncExternalStoreParameters());
+  const snapshot = React.useSyncExternalStore(...mockStore.getUseSyncExternalStoreArgs());
 
   const onFetchSync = () => {
     mockStore.fetchSync();

--- a/src/sync-external-store/sync-external-store.ts
+++ b/src/sync-external-store/sync-external-store.ts
@@ -38,7 +38,7 @@ export class SyncExternalStore<TSnapshot> implements ISyncExternalStore<TSnapsho
 
   getServerSnapshot = undefined;
 
-  getSyncExternalStoreParameters = () => {
+  getUseSyncExternalStoreArgs = () => {
     return [this.subscribe, this.getSnapshot, this.getServerSnapshot] as const;
   };
   protected updateSnapshot(newSnapshot: ((prevSnapshot: TSnapshot) => TSnapshot) | TSnapshot) {


### PR DESCRIPTION
Last Release didn't happen, sneaking this in